### PR TITLE
Add deploy to web stores Github Action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: "Submit to Web Store"
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.2
+      - name: Install dependencies
+        run: npm install
+      - name: Build package
+        run: npm run build
+      - name: Browser Plugin Publish
+        uses: plasmo-corp/bpp@v1
+        with:
+          keys: ${{ secrets.SUBMIT_KEYS }}

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -48,9 +48,11 @@ function processCss(css, outdir, resdir) {
 
 async function build(browser) {
     const outdir = path.join(__dirname, `/../build-${browser}`);
-
-    fs.rmdirSync(outdir, { recursive: true });
+    if(fs.existsSync(outdir)){
+        fs.rmSync(outdir, { recursive: true });
+    }
     fs.mkdirSync(outdir, { recursive: true });
+
     fs.writeFileSync(outdir + '/manifest.json', manifest(browser));
 
     copyFiles(path.join(indir, 'icons'), outdir);


### PR DESCRIPTION
Hiya! We created a [Github action](https://github.com/marketplace/actions/browser-plugin-publisher) to make it easier to publish extensions to the various web stores.

Thought you might find it useful so I added a Github workflow that will build the extension, zip it up, and publish to the web stores on dispatch.

The only thing you would need to create is a `SUBMIT_KEYS` GitHub repository secret.

This secret is a JSON, with the schema defined [here](https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json).

Here's a sample json blob with the proper zip file location already pre-filled (the `{version}` in the zip file name will automatically be substituted for whatever version's in the `package.json`) :

```
{
  "$schema": "https://raw.githubusercontent.com/plasmo-corp/bpp/v1/keys.schema.json",
  "chrome": {
    "zip": "build-chrome/jsondiscovery-chrome-{version}.zip",
    "clientId": "123",
    "clientSecret": "456",
    "refreshToken": "789",
    "extId": "abcd"
  },
  "firefox": {
    "zip": "build-firefox/jsondiscovery-firefox-{version}.zip",
    "apiKey": "123",
    "apiSecret": "abcd",
    "extId": "foobar"
  }
}
```
You can find instructions on how to get those keys in the schema, or if you use vscode, the schema should provide hint/intelisense when hovering over the json properties. If you need any help in setting up the keys, feel free to @ me.

Otherwise, if this doesn't seem necessary, feel free to close the PR!


(p.s. I also fixed an issue where the build script would fail if the `build-*` directories weren't present on the file system by adding a little check to that code) 